### PR TITLE
Add Ethereum MCP module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python caches
+__pycache__/
+
+# Node modules
+node_modules/
+
+# Environment files
+*.env
+
+# Build outputs

--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ The core trading engine that:
 git clone https://github.com/your-username/ai-event-trader.git
 cd ai-event-trader
 npm install
+
+### Ethereum MCP (Experimental)
+
+This repository now includes a minimal Ethereum MCP module in `ethereum-mcp/`. It provides
+helpers for querying Ethereum via ethers.js, executing token swaps through 1inch and
+staking ETH with Lido. To enable it:
+
+1. Copy `ethereum-mcp/.env.example` to `ethereum-mcp/.env` and fill in your RPC URL and keys.
+2. Run `npm install` inside `ethereum-mcp` and build with `npm run build`.
+3. Update `fastagent.config.yaml` to start the `ethereum` server.
+
+The Polygon functionality remains the default, but you can experiment with Ethereum
+support by running the new server.

--- a/ethereum-mcp/.env.example
+++ b/ethereum-mcp/.env.example
@@ -1,0 +1,5 @@
+# Rename to .env and fill in values
+SEED_PHRASE=""
+ETHEREUM_RPC_URL="https://mainnet.infura.io/v3/YOUR_PROJECT_ID"
+ONEINCH_API_KEY=""
+ETHERSCAN_API_KEY=""

--- a/ethereum-mcp/build/index.js
+++ b/ethereum-mcp/build/index.js
@@ -1,0 +1,44 @@
+import 'dotenv/config';
+import axios from 'axios';
+import { ethers } from 'ethers';
+const RPC_URL = process.env.ETHEREUM_RPC_URL || '';
+const MNEMONIC = process.env.SEED_PHRASE || '';
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const wallet = ethers.HDNodeWallet.fromPhrase(MNEMONIC).connect(provider);
+export async function getBalance(address) {
+  const bal = await provider.getBalance(address);
+  return ethers.formatEther(bal);
+}
+export async function getTransaction(hash) {
+  return provider.getTransaction(hash);
+}
+export async function swapToken(fromToken, toToken, amount, slippage) {
+  const oneInchApiKey = process.env.ONEINCH_API_KEY || '';
+  const fromAddress = await wallet.getAddress();
+  const url = `https://api.1inch.io/v5.0/1/swap?fromTokenAddress=${fromToken}&toTokenAddress=${toToken}&amount=${amount}&fromAddress=${fromAddress}&slippage=${slippage}&disableEstimate=true&apikey=${oneInchApiKey}`;
+  const { data } = await axios.get(url);
+  const tx = data.tx;
+  const txResponse = await wallet.sendTransaction({
+    to: tx.to,
+    data: tx.data,
+    value: tx.value ? ethers.toBigInt(tx.value) : 0n,
+    gasLimit: tx.gas,
+    maxFeePerGas: tx.gasPrice,
+  });
+  return await txResponse.wait();
+}
+export async function stakeEthWithLido(amount) {
+  const LIDO_CONTRACT = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
+  const tx = await wallet.sendTransaction({
+    to: LIDO_CONTRACT,
+    value: ethers.parseEther(amount),
+  });
+  return await tx.wait();
+}
+if (require.main === module) {
+  (async () => {
+    const addr = await wallet.getAddress();
+    const bal = await getBalance(addr);
+    console.log(`Wallet: ${addr} - Balance: ${bal} ETH`);
+  })();
+}

--- a/ethereum-mcp/package.json
+++ b/ethereum-mcp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ethereum-mcp",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "dotenv": "^16.3.1",
+    "ethers": "^6.6.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/ethereum-mcp/src/index.ts
+++ b/ethereum-mcp/src/index.ts
@@ -1,0 +1,56 @@
+import 'dotenv/config';
+import axios from 'axios';
+import { ethers } from 'ethers';
+
+const RPC_URL = process.env.ETHEREUM_RPC_URL || '';
+const MNEMONIC = process.env.SEED_PHRASE || '';
+
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const wallet = ethers.HDNodeWallet.fromPhrase(MNEMONIC).connect(provider);
+
+export async function getBalance(address: string) {
+  const bal = await provider.getBalance(address);
+  return ethers.formatEther(bal);
+}
+
+export async function getTransaction(hash: string) {
+  return provider.getTransaction(hash);
+}
+
+export async function swapToken(
+  fromToken: string,
+  toToken: string,
+  amount: string,
+  slippage: number
+) {
+  const oneInchApiKey = process.env.ONEINCH_API_KEY || '';
+  const fromAddress = await wallet.getAddress();
+  const url = `https://api.1inch.io/v5.0/1/swap?fromTokenAddress=${fromToken}&toTokenAddress=${toToken}&amount=${amount}&fromAddress=${fromAddress}&slippage=${slippage}&disableEstimate=true&apikey=${oneInchApiKey}`;
+  const { data } = await axios.get(url);
+  const tx = data.tx;
+  const txResponse = await wallet.sendTransaction({
+    to: tx.to,
+    data: tx.data,
+    value: tx.value ? ethers.toBigInt(tx.value) : 0n,
+    gasLimit: tx.gas,
+    maxFeePerGas: tx.gasPrice,
+  });
+  return await txResponse.wait();
+}
+
+export async function stakeEthWithLido(amount: string) {
+  const LIDO_CONTRACT = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
+  const tx = await wallet.sendTransaction({
+    to: LIDO_CONTRACT,
+    value: ethers.parseEther(amount),
+  });
+  return await tx.wait();
+}
+
+if (require.main === module) {
+  (async () => {
+    const addr = await wallet.getAddress();
+    const bal = await getBalance(addr);
+    console.log(`Wallet: ${addr} - Balance: ${bal} ETH`);
+  })();
+}

--- a/ethereum-mcp/tsconfig.json
+++ b/ethereum-mcp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "build",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/fastagent.config.yaml
+++ b/fastagent.config.yaml
@@ -10,3 +10,7 @@ mcp:
       command: "node" # Start command
       args: ["./polygon-mcp/build/index.js"] # Command arguments
       # don't forget config SEED_PHRASE in polygon-mcp/.env
+    ethereum: # Ethereum MCP server configuration
+      command: "node"
+      args: ["./ethereum-mcp/build/index.js"]
+      # copy ethereum-mcp/.env.example to ethereum-mcp/.env and set values


### PR DESCRIPTION
## Summary
- add experimental `ethereum-mcp` module with sample TypeScript implementation
- document how to use the Ethereum module in `README.md`
- update `fastagent.config.yaml` to include ethereum server
- add repository `.gitignore`

## Testing
- `python -m py_compile chat.py quantar.py webhook-sdk/*.py farcaster_monitor/*.py`
